### PR TITLE
Fixed missing import

### DIFF
--- a/wine_env/bottle.py
+++ b/wine_env/bottle.py
@@ -2,6 +2,7 @@ from wine_env import wine_rc
 import argparse
 import os
 import re
+import sys
 
 
 def main() -> None:


### PR DESCRIPTION
Running bottle with a path which is not an executable throws an exception because sys wasn't imported.